### PR TITLE
Add middleware for Echo

### DIFF
--- a/middleware/echo.go
+++ b/middleware/echo.go
@@ -1,0 +1,31 @@
+package middleware
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/kyani-inc/go-utils/ip"
+	"gopkg.in/kyani-inc/logger.v2"
+
+	"github.com/labstack/echo"
+)
+
+func Echo(log logger.Client) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c *echo.Context) error {
+			start := time.Now()
+
+			// Get a single IP Address of the connecting party
+			addr := ip.Client(c.Request())
+
+			if err := next(c); err != nil {
+				c.Error(err)
+			}
+
+			latency := time.Since(start)
+			log.Infof("%v %s %s %v %s \"%s\"", c.Response().Status(), http.StatusText(c.Response().Status()), c.Request().Method, latency, c.Request().URL.Path, addr)
+
+			return nil
+		}
+	}
+}

--- a/middleware/martini.go
+++ b/middleware/martini.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kyani-inc/logger"
 )
 
-// Papertrail is a Martini Middleware that emulates their default logger in
+// Martini is a Martini Middleware that emulates their default logger in
 // the sense that it logs every request and sends it to Papertrail.
 // The logger gets the following info:
 // 	- Time taken for request
@@ -21,7 +21,7 @@ import (
 //
 // The result appears in Papertrail as:
 // [info] 200 OK HEAD 1.109259ms /my/endpoint/ "8.8.8.8"
-func Papertrail() martini.Handler {
+func Martini() martini.Handler {
 	return func(res http.ResponseWriter, req *http.Request, c martini.Context, log logger.Client) {
 		start := time.Now()
 


### PR DESCRIPTION
Adds a middleware for the Echo framework.

Also renames the other available middleware from "Papertrail" to "Martini" as it was always only a Martini middleware.

@crit could you look over this.
