### PR TITLE
Add the ability to add context aware prefixes to a log

### DIFF
--- a/middleware/echo.go
+++ b/middleware/echo.go
@@ -5,12 +5,12 @@ import (
 	"time"
 
 	"github.com/kyani-inc/go-utils/ip"
-	"gopkg.in/kyani-inc/logger.v2"
+	"github.com/kyani-inc/logger"
 
 	"github.com/labstack/echo"
 )
 
-func Echo(log logger.Client) echo.MiddlewareFunc {
+func Echo(log logger.Client, prefixes ...interface{}) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c *echo.Context) error {
 			start := time.Now()
@@ -23,7 +23,9 @@ func Echo(log logger.Client) echo.MiddlewareFunc {
 			}
 
 			latency := time.Since(start)
-			log.Infof("%v %s %s %v %s \"%s\"", c.Response().Status(), http.StatusText(c.Response().Status()), c.Request().Method, latency, c.Request().URL.Path, addr)
+			// Create the prefix for the logger
+			prefix := makePrefixes(c, prefixes...)
+			log.Infof("%s%v %s %s %v %s \"%s\"", prefix, c.Response().Status(), http.StatusText(c.Response().Status()), c.Request().Method, latency, c.Request().URL.Path, addr)
 
 			return nil
 		}

--- a/middleware/martini.go
+++ b/middleware/martini.go
@@ -21,7 +21,7 @@ import (
 //
 // The result appears in Papertrail as:
 // [info] 200 OK HEAD 1.109259ms /my/endpoint/ "8.8.8.8"
-func Martini() martini.Handler {
+func Martini(prefixes ...interface{}) martini.Handler {
 	return func(res http.ResponseWriter, req *http.Request, c martini.Context, log logger.Client) {
 		start := time.Now()
 
@@ -31,6 +31,7 @@ func Martini() martini.Handler {
 		rw := res.(martini.ResponseWriter)
 		c.Next()
 
-		log.Infof("%v %s %s %v %s \"%s\"", rw.Status(), http.StatusText(rw.Status()), req.Method, time.Since(start), req.URL.Path, addr)
+		prefix := makePrefixes(c, prefixes...)
+		log.Infof("%s%v %s %s %v %s \"%s\"", prefix, rw.Status(), http.StatusText(rw.Status()), req.Method, time.Since(start), req.URL.Path, addr)
 	}
 }

--- a/middleware/prefixes.go
+++ b/middleware/prefixes.go
@@ -1,0 +1,30 @@
+package middleware
+
+import (
+	"fmt"
+
+	"github.com/go-martini/martini"
+	"github.com/labstack/echo"
+)
+
+func makePrefixes(c interface{}, prefixes ...interface{}) (prefix string) {
+	if len(prefixes) == 0 {
+		return
+	}
+
+	for _, pfx := range prefixes {
+		switch pfx := pfx.(type) {
+		case string:
+			prefix += fmt.Sprintf("[%s]", pfx)
+		case func(c *echo.Context) string:
+			prefix += fmt.Sprintf("[%s]", pfx(c.(*echo.Context)))
+		case func(c martini.Context) string:
+			prefix += fmt.Sprintf("[%s]", pfx(c.(martini.Context)))
+		default:
+			prefix += fmt.Sprintf("[%v]", pfx)
+		}
+	}
+
+	prefix += " "
+	return
+}


### PR DESCRIPTION
This allows you to create context aware prefixes for your logs to prefix logs by something like an app name or a request id. Usage follows (TODO move to a test):

```
middleware.Echo(log, "my-app", prefix)

...
func prefix(c *echo.Context) string {
   return c.Value("Request-ID").(string)
}
```

Yields the following:

```
[my-app][Vmi67yXcmi_pZdZl] 200 OK GET 30.053µs / "::1"
```
